### PR TITLE
cmake: Update minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 #       start libevent.sln
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)

--- a/test-export/CMakeLists.txt
+++ b/test-export/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.2)
+cmake_minimum_required(VERSION 3.10)
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)
 endif()


### PR DESCRIPTION
CMake < 3.5 compatibility has been removed from CMake 4.0 and CMake < 3.10 compatibility has been deprecated in CMake 3.31.

https://cmake.org/cmake/help/latest/release/4.0.html
https://cmake.org/cmake/help/latest/release/3.31.html

Cherry-picked from 2d7a3b9b6a7c7ef0d651d866b4ab11fb1ea24664.