### PR TITLE
Android: revert "Add postfix for Debug configuration"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,14 +38,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 
-# Usually it is OK to define it unconditionally, but the problem is that we use
-# CMAKE_DEBUG_POSTFIX in *.pc.in
-if (CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
-    if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
-        set(CMAKE_DEBUG_POSTFIX d)
-    endif()
-endif()
-
 set(EVENT__LIBRARY_TYPE DEFAULT CACHE STRING
     "Set library type to SHARED/STATIC/BOTH (default SHARED for MSVC, otherwise BOTH)")
 


### PR DESCRIPTION
First of all, Transmission's fork of libevent needs a `post-2.2.0-transmission` branch:
https://github.com/transmission/libevent/branches/all

Once created, we can retarget this PR to the new 2.2 branch.

Then, regarding the scope of this PR, it's the same as https://github.com/libevent/libevent/pull/1817 and is needed for Transmission to migrate from libevent 2.1 to libevent 2.2 (https://github.com/transmission/transmission/pull/7765).