### PR TITLE
Win32: check for bcrypt.lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ if (WIN32)
     list(APPEND SYMBOLS_TO_CHECK
         _gmtime64
         _gmtime64_s
+        BCryptGenRandom
     )
 else()
     list(APPEND SYMBOLS_TO_CHECK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,7 +533,6 @@ if (WIN32)
     list(APPEND SYMBOLS_TO_CHECK
         _gmtime64
         _gmtime64_s
-        BCryptGenRandom
     )
 else()
     list(APPEND SYMBOLS_TO_CHECK

--- a/arc4random.c
+++ b/arc4random.c
@@ -52,7 +52,7 @@
 #ifndef ARC4RANDOM_NO_INCLUDES
 #include "evconfig-private.h"
 #ifdef _WIN32
-#ifndef EVENT__HAVE_BCRYPTGENRANDOM
+#ifndef EVENT__HAVE_BCRYPT_LIB
 #include <wincrypt.h>
 #else
 #include <bcrypt.h>
@@ -157,7 +157,7 @@ static int
 arc4_seed_win32(void)
 {
 	unsigned char buf[ADD_ENTROPY];
-#ifndef EVENT__HAVE_BCRYPTGENRANDOM
+#ifndef EVENT__HAVE_BCRYPT_LIB
 	/* This is adapted from Tor's crypto_seed_rng() */
 	static int provider_set = 0;
 	static HCRYPTPROV provider;

--- a/arc4random.c
+++ b/arc4random.c
@@ -52,7 +52,7 @@
 #ifndef ARC4RANDOM_NO_INCLUDES
 #include "evconfig-private.h"
 #ifdef _WIN32
-#ifndef EVENT__HAVE_BCRYPT_LIB
+#ifndef EVENT__HAVE_BCRYPTGENRANDOM
 #include <wincrypt.h>
 #else
 #include <bcrypt.h>
@@ -157,7 +157,7 @@ static int
 arc4_seed_win32(void)
 {
 	unsigned char buf[ADD_ENTROPY];
-#ifndef EVENT__HAVE_BCRYPT_LIB
+#ifndef EVENT__HAVE_BCRYPTGENRANDOM
 	/* This is adapted from Tor's crypto_seed_rng() */
 	static int provider_set = 0;
 	static HCRYPTPROV provider;

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -285,6 +285,9 @@
 /* Define to 1 if you have the `_gmtime64' function. */
 #cmakedefine EVENT__HAVE__GMTIME64 1
 
+/* Define to 1 if you have the `BCryptGenRandom' function. */
+#cmakedefine EVENT__HAVE_BCRYPTGENRANDOM 1
+
 /* Define to 1 if the system has the type `struct addrinfo'. */
 #cmakedefine EVENT__HAVE_STRUCT_ADDRINFO 1
 

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -285,8 +285,8 @@
 /* Define to 1 if you have the `_gmtime64' function. */
 #cmakedefine EVENT__HAVE__GMTIME64 1
 
-/* Define to 1 if you have the `BCryptGenRandom' function. */
-#cmakedefine EVENT__HAVE_BCRYPTGENRANDOM 1
+/* Define to 1 if you link with `bcrypt.lib'. */
+#cmakedefine EVENT__HAVE_BCRYPT_LIB 1
 
 /* Define to 1 if the system has the type `struct addrinfo'. */
 #cmakedefine EVENT__HAVE_STRUCT_ADDRINFO 1

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -285,8 +285,8 @@
 /* Define to 1 if you have the `_gmtime64' function. */
 #cmakedefine EVENT__HAVE__GMTIME64 1
 
-/* Define to 1 if you link with `bcrypt.lib'. */
-#cmakedefine EVENT__HAVE_BCRYPT_LIB 1
+/* Define to 1 if you have the `BCryptGenRandom' function. */
+#cmakedefine EVENT__HAVE_BCRYPTGENRANDOM 1
 
 /* Define to 1 if the system has the type `struct addrinfo'. */
 #cmakedefine EVENT__HAVE_STRUCT_ADDRINFO 1


### PR DESCRIPTION
First of all, Transmission's fork of libevent needs a `post-2.2.0-transmission` branch:
https://github.com/transmission/libevent/branches/all

Once created, we can retarget this PR to the new 2.2 branch.

Then, regarding the scope of this PR, it's the same as https://github.com/libevent/libevent/pull/1813 and is needed for Transmission to migrate from libevent 2.1 to libevent 2.2 (https://github.com/transmission/transmission/pull/7765).