### PR TITLE
cmake: set CMP0090 to new

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ endif()
 if (POLICY CMP0075)
     cmake_policy(SET CMP0075 NEW)
 endif()
+if (POLICY CMP0090)
+	cmake_policy(SET CMP0090 NEW)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release


### PR DESCRIPTION
Prevent libevent from being added to the package registry and mess up other builds when used as `add_subdirectory(libevent)` .

Cherry-pick https://github.com/libevent/libevent/commit/4ab9ca0eeb666562faa81f51860cbca2f64df6ef.